### PR TITLE
Add Block DX order books 

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,8 +377,8 @@ If you know in details or are you the owner/dev of any DEX, please fill the colu
 
 ## DEX Order Books:
 
-[https://etherscan.io/orderbooks](https://etherscan.io/orderbooks)
-[https://blockdx.co](https://blockdx.co)
++ [https://etherscan.io/orderbooks](https://etherscan.io/orderbooks)
++ [https://blockdx.co](https://blockdx.co)
 
 ## DEX Order Tracker:
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ If you know in details or are you the owner/dev of any DEX, please fill the colu
 ## DEX Order Books:
 
 [https://etherscan.io/orderbooks](https://etherscan.io/orderbooks)
+[https://blockdx.co](https://blockdx.co)
 
 ## DEX Order Tracker:
 


### PR DESCRIPTION
In the DEX Order Books section, please add blockdx.co which displays real time orders on the Block DX network. Thanks and great site!