### PR TITLE
Fix broken Paradigm whitepaper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Many thanks to all the contributors, especially to [@amisolution](https://github
 | Open Trading Network | [![alt text][web]](https://otn.org/) | [![alt text][github]](https://github.com/OpenTradingNetworkFoundation) | [![alt text][whitepaper]](https://otn.org/assets/resources/Open-Trading-Network-white-paper_en.pdf) |   | (dev) | otn protocol |   |   |   |   |   |
 | 	Orderbook	| 	[![alt text][web]](https://www.orderbook.io) | [![alt text][github]](https://github.com/Orderbookio)	| [![alt text][whitepaper]](https://ico.orderbook.io/files/orderbook_WP.pdf)  | | 	(released)	| 	ethereum protocol	| 	| | | | |
 | 	Paradex	| 	[![alt text][web]](https://app.paradex.io/) | [![alt text][github]](https://github.com/ParadexRelayer)	| | | 	(operating - beta)	| 	0x protocol	| 	| | | | |
-| 	Paradigm	| 	[![alt text][web]](https://paradigm.market/) | [![alt text][github]](https://github.com/ParadigmFoundation)	| [![alt text][whitepaper]](https://paradigm.market/whitepaper) | `FULLY`  | 	(dev)	| 	paradigm protocol	| 	| | | | |
+| 	Paradigm	| 	[![alt text][web]](https://paradigm.market/) | [![alt text][github]](https://github.com/ParadigmFoundation)	| [![alt text][whitepaper]](https://paradigm.market/whitepaper.pdf) | `FULLY`  | 	(dev)	| 	paradigm protocol	| 	| | | | |
 | Plaak | [![alt text][web]](http://exchange.plaak.com/landing.php) | [![alt text][github]](https://github.com/zeked2013/PLAAK) | [![alt text][whitepaper]](http://plaak.com/docs/PLAAK-Whitepaper-V2-Freelance.pdf) | `DCD` | (dev) | TBC |   | | | | |
 | 	PlutusDEX |	[![alt text][web]](https://dex.plutus.it/) | | | |	(operating) |	TBC |	 | | | | |
 | 	Prime |	[![alt text][web]](https://getprime.org/) | [![alt text][github]](https://github.com/hitchhiker/prime) | | |	(dev - pre-alpha) |	TBC |	 | | | | |


### PR DESCRIPTION
The link now points to `/whitepaper.pdf` instead of `/whitepaper`. Necessary after we switched our static file server. Thanks!