### PR TITLE
Update 0x Tracker url

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ If you know in details or are you the owner/dev of any DEX, please fill the colu
 ## DEX Order Tracker:
 
 + [https://etherscan.io/dextracker](https://etherscan.io/dextracker)
-+ [https://0xtracker.com/trades](https://0xtracker.com/trades)
++ [https://0xtracker.com/fills](https://0xtracker.com/fills)
 + [https://dex.watch/](https://dex.watch/)
 
 ## DEX price comparison tools:
@@ -420,7 +420,7 @@ If you know in details or are you the owner/dev of any DEX, please fill the colu
 ## DEX Trackers Statistics:
 
 + [https://etherscan.io/stat/dextracker](https://etherscan.io/stat/dextracker)
-+ [https://0xtracker.com](https://0xtracker.com/relays)
++ [https://0xtracker.com](https://0xtracker.com/)
 + [https://dex.watch/](https://dex.watch/)
 
 ## Protocols for Decentralized Exchange


### PR DESCRIPTION
Updating the 0x tracker trades URL as the current ones are 404s.